### PR TITLE
Support current Neutron code (Mitaka) as well as Liberty

### DIFF
--- a/_test-requirements.txt
+++ b/_test-requirements.txt
@@ -19,4 +19,4 @@ testscenarios>=0.4
 testtools>=0.9.36,!=1.2.0
 
 -e git+https://github.com/projectcalico/calico.git#egg=calico-git
--e git://git.openstack.org/openstack/neutron.git@stable/liberty#egg=neutron
+-e git://git.openstack.org/openstack/neutron.git#egg=neutron

--- a/devstack/bootstrap.sh
+++ b/devstack/bootstrap.sh
@@ -19,34 +19,51 @@ set -ex
 #------------------------------------------------------------------------------
 # IMPORTANT - Review before use!
 #
-# This script can be used to bootstrap a single or multi-node
-# Calico/DevStack cluster.  Please note that it has not been
-# exhaustively reviewed or tested and safety, and is designed for use
-# on a fresh Ubuntu Trusty VM, with no data that you would care about
-# losing.  We recommend that you review the following code, before
-# running the script.
+# This script can be used to bootstrap a single or multi-node Calico/DevStack
+# cluster.  Please note that it has not been exhaustively reviewed or tested
+# for safety, and is designed for use on a fresh Ubuntu Trusty VM, with no data
+# that you would care about losing.  We recommend that you review the following
+# code, before running the script.
 #------------------------------------------------------------------------------
 
 #------------------------------------------------------------------------------
 # Environment Variables
 #
-# If the SERVICE_HOST environment variable is already set when
-# ./stack.sh is run, and is _different_ from the local machine's
-# hostname, the networking-calico DevStack plugin will interpret that
-# as a request to set up a compute-only node, that points to
-# $SERVICE_HOST as its controller.
+# SERVICE_HOST
 #
-# On the other hand, if SERVICE_HOST is not set, or is the _same_ as
-# the local hostname, the plugin will set up a combined controller and
-# compute node.
+#     If the SERVICE_HOST environment variable is already set when ./stack.sh
+#     is run, and is _different_ from the local machine's hostname, the
+#     networking-calico DevStack plugin will interpret that as a request to set
+#     up a compute-only node, that points to $SERVICE_HOST as its controller.
 #
-# Therefore, to bring up a multi-node Calico/DevStack cluster, set and
-# export SERVICE_HOST in the environment, to the hostname for the chosen
-# controller node in your cluster, before invoking this script.
+#     On the other hand, if SERVICE_HOST is not set, or is the _same_ as the
+#     local hostname, the plugin will set up a combined controller and compute
+#     node.
 #
-# For a single node Calico/DevStack cluster, the environment should
-# leave SERVICE_HOST unset.
-#------------------------------------------------------------------------------
+#     Therefore, to bring up a multi-node Calico/DevStack cluster, set and
+#     export SERVICE_HOST in the environment, to the hostname for the chosen
+#     controller node in your cluster, before invoking this script.
+#
+#     For a single node Calico/DevStack cluster, the environment should leave
+#     SERVICE_HOST unset.
+#
+# TEST_GERRIT_CHANGE
+#
+#     By default this script uses the master branch of networking-calico.  To
+#     test a networking-calico change in Gerrit that hasn't yet been merged to
+#     master, set the TEST_GERRIT_CHANGE environment variable to indicate that
+#     change, before running this script; for example:
+#
+#         export TEST_GERRIT_CHANGE=219646/1
+#
+# DEVSTACK_BRANCH
+#
+#     By default this script uses the master branch of devstack.  To use a
+#     different branch, set the DEVSTACK_BRANCH environment variable before
+#     running this script; for example:
+#
+#         export DEVSTACK_BRANCH=stable/liberty
+# ------------------------------------------------------------------------------
 
 # Assume that we are starting from the home directory of a non-root
 # user that can sudo, and hence is suitable for running DevStack.  For
@@ -66,13 +83,7 @@ sudo apt-get -y install git
 git clone https://git.openstack.org/openstack/networking-calico
 cd networking-calico
 
-# If you want to test a networking-calico change in Gerrit that hasn't
-# yet been merged to master, set the TEST_GERRIT_CHANGE environment
-# variable to indicate that change, before running this script; for
-# example:
-#
-#    export TEST_GERRIT_CHANGE=219646/1
-#
+# If TEST_GERRIT_CHANGE has been specified, merge that change from Gerrit.
 if [ -n "$TEST_GERRIT_CHANGE" ]; then
     git fetch https://review.openstack.org/openstack/networking-calico \
 	refs/changes/${TEST_GERRIT_CHANGE:4:2}/${TEST_GERRIT_CHANGE}
@@ -92,10 +103,13 @@ sudo sysctl -w net.ipv6.conf.all.forwarding=1
 
 # Clone the DevStack repository.
 git clone https://git.openstack.org/openstack-dev/devstack
-
-# Use the stable/liberty branch.
 cd devstack
-git checkout stable/liberty
+
+# If DEVSTACK_BRANCH has been specified, check out that branch.  (Otherwise we
+# use DevStack's master branch.)
+if [ -n "$DEVSTACK_BRANCH" ]; then
+    git checkout ${DEVSTACK_BRANCH}
+fi
 
 # Prepare DevStack config.
 cat > local.conf <<EOF
@@ -121,5 +135,5 @@ EOF
 if [ x${SERVICE_HOST:-$HOSTNAME} = x$HOSTNAME ]; then
     . openrc admin admin
     neutron net-create --shared --provider:network_type local calico
-    neutron subnet-create --gateway 10.65.0.1 --enable-dhcp --ip-version 4 --name calico-v4 calico 10.65.0/24
+    neutron subnet-create --gateway 10.65.0.1 --enable-dhcp --ip-version 4 --name calico-v4 calico 10.65.0.0/24
 fi

--- a/networking_calico/agent/dhcp_agent.py
+++ b/networking_calico/agent/dhcp_agent.py
@@ -101,6 +101,25 @@ class FakePlugin(object):
         LOG.debug("release_dhcp_port: %s %s", network_id, device_id)
 
 
+def empty_network():
+    """Construct and return an empty network model."""
+    return make_net_model({"id": NETWORK_ID,
+                           "subnets": [],
+                           "ports": [],
+                           "mtu": constants.DEFAULT_NETWORK_MTU})
+
+
+def make_net_model(net_spec):
+    try:
+        net_model = dhcp.NetModel(False, net_spec)
+    except TypeError:
+        # use_namespace option was removed during Mitaka cycle.
+        net_model = dhcp.NetModel(net_spec)
+        net_model._ns_name = None
+
+    return net_model
+
+
 class CalicoEtcdWatcher(EtcdWatcher):
 
     NETWORK_ID = 'calico'
@@ -117,14 +136,6 @@ class CalicoEtcdWatcher(EtcdWatcher):
     with ID 'calico', and many subnets within that network.
     """
 
-    def _empty_network(self):
-        """Construct and return an empty network model."""
-        return dhcp.NetModel(False,
-                             {"id": NETWORK_ID,
-                              "subnets": [],
-                              "ports": [],
-                              "mtu": constants.DEFAULT_NETWORK_MTU})
-
     def __init__(self, agent):
         super(CalicoEtcdWatcher, self).__init__(
             '127.0.0.1:4001',
@@ -134,7 +145,7 @@ class CalicoEtcdWatcher(EtcdWatcher):
         self.suppress_on_ports_changed = False
 
         # Create empty Calico network object in the cache.
-        self.agent.cache.put(self._empty_network())
+        self.agent.cache.put(empty_network())
 
         # Register the etcd paths that we need to watch.
         self.register_path(
@@ -281,12 +292,11 @@ class CalicoEtcdWatcher(EtcdWatcher):
             self.agent.call_driver('reload_allocations', net)
         else:
             # Subnets changed, so need to 'restart' the DHCP driver.
-            net = dhcp.NetModel(False,
-                                {"id": net.id,
-                                 "subnets": new_subnets,
-                                 "ports": net.ports,
-                                 "tenant_id": "calico",
-                                 "mtu": constants.DEFAULT_NETWORK_MTU})
+            net = make_net_model({"id": net.id,
+                                  "subnets": new_subnets,
+                                  "ports": net.ports,
+                                  "tenant_id": "calico",
+                                  "mtu": constants.DEFAULT_NETWORK_MTU})
             LOG.debug("new net: %s %s %s", net.id, net.subnets, net.ports)
 
             # Next line - i.e. just discarding the existing cache - is to work
@@ -383,7 +393,7 @@ class CalicoEtcdWatcher(EtcdWatcher):
         # Reset the cache.
         LOG.debug("Reset cache for new snapshot")
         self.agent.cache = NetworkCache()
-        self.agent.cache.put(self._empty_network())
+        self.agent.cache.put(empty_network())
 
         # Suppress the processing inside on_ports_changed, until we've
         # processed the whole snapshot.
@@ -462,7 +472,6 @@ class CalicoDhcpAgent(DhcpAgent):
 
         # Override settings that Calico's DHCP agent use requires.
         self.conf.set_override('enable_isolated_metadata', False)
-        self.conf.set_override('use_namespaces', False)
         self.conf.set_override(
             'interface_driver',
             'networking_calico.agent.linux.interface.RoutedInterfaceDriver'

--- a/networking_calico/tests/test_interface_driver.py
+++ b/networking_calico/tests/test_interface_driver.py
@@ -25,21 +25,14 @@ class TestInterfaceDriver(base.BaseTestCase):
     def setUp(self):
         super(TestInterfaceDriver, self).setUp()
         config.register_interface_driver_opts_helper(cfg.CONF)
-        config.register_use_namespaces_opts_helper(cfg.CONF)
         cfg.CONF.register_opts(interface.OPTS)
-        cfg.CONF.set_override('use_namespaces', False)
 
     @mock.patch('neutron.agent.linux.ip_lib.IPDevice')
     @mock.patch.object(interface.LinuxInterfaceDriver, 'init_l3')
     def test_init_l3(self, init_l3, ipdev_cls):
         self.driver = RoutedInterfaceDriver(cfg.CONF)
         self.driver.init_l3('ns-dhcp', ['10.65.0.1/24'])
-        init_l3.assert_called_with('ns-dhcp',
-                                   ['10.65.0.1/24'],
-                                   None,
-                                   [],
-                                   None,
-                                   [])
-        ipdev_cls.assert_called_with('ns-dhcp', namespace=None)
+        init_l3.assert_called_with('ns-dhcp', ['10.65.0.1/24'])
+        ipdev_cls.assert_called_with('ns-dhcp')
         ipdev = ipdev_cls.return_value
         ipdev.route.delete_onlink_route.assert_called_with('10.65.0.0/24')

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ usedevelop = True
 install_command = pip install -U {opts} {packages}
 setenv =
    VIRTUAL_ENV={envdir}
-deps = -r{toxinidir}/test-requirements.txt
-commands = 
+deps = -r{toxinidir}/_test-requirements.txt
+commands =
     coverage erase
     python setup.py test --slowest --testr-args='{posargs}'
     coverage report -m


### PR DESCRIPTION
This change modifies networking-calico's requirements and DevStack setup
so as to use master Neutron code instead of stable/liberty, and adapts
networking-calico's code as necessary so that it works with the Neutron
master code, as well as continuing to work with Liberty and previous
OpenStack releases.  As we're now very close to the Mitaka release,
working with master Neutron code should also mean working with the
Mitaka release.

DevStack bootstrap script changes:

- Use master DevStack by default (which means using master of all
  OpenStack code), but support arbitrary devstack branch via the new
  DEVSTACK_BRANCH variable.
- Improve commenting about supported environment variables.
- Change subnet CIDR from 10.65.0/24 to 10.65.0.0/24, as Neutron
  apparently now requires full length.

Adapt networking-calico code for removal of deprecated use_namespaces
option:

- Don't override use_namespaces, as it no longer exists to be
  overridden.
- Handle new Mitaka NetModel calls that don't allow a use_namespaces
  argument, and set _ns_name attribute to get equivalent effect.
- Use subclassing to override pieces of the DHCP agent implementation
  that assume they own their own namespace (and so delete unknown
  devices, and set the default route).

Adapt networking-calico code for other Neutron changes since Liberty:

- neutron.agent.linux.dhcp's commonutils import changed to common_utils.
- DHCP agent code now requires NetModel.mtu to be a number (or else for
  'advertise_mtu' to be configured False).
- New mtu parameter in RoutedInterfaceDriver.plug_new.
- Adjust test code for different eventlet thread timing.

Test requirements:

- Use master Neutron code instead of stable/liberty.
- Hide test requirements from DevStack.  DevStack's installation of test
  requirements is currently failing [1], so avoid that by renaming the
  file.

  [1] https://bugs.launchpad.net/devstack/+bug/1540328

Change-Id: Ib580639dc341df8a931a947fb3d82f97d656a32b
Sem-Ver: feature