### PR TITLE
calico dhcp agent should run as unprivileged neutron user

### DIFF
--- a/rpm/calico-dhcp-agent.service
+++ b/rpm/calico-dhcp-agent.service
@@ -3,7 +3,7 @@ Description=Calico DHCP agent
 After=syslog.target network.target
 
 [Service]
-User=root
+User=neutron
 ExecStart=/usr/bin/calico-dhcp-agent --config-file /etc/neutron/neutron.conf
 KillMode=process
 Restart=on-failure

--- a/rpm/networking-calico.spec
+++ b/rpm/networking-calico.spec
@@ -4,12 +4,12 @@ Name:           networking-calico
 Summary:        Project Calico networking for OpenStack/Neutron
 Epoch:          1
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Apache-2
 URL:            http://docs.openstack.org/developer/networking-calico/
 Source0:        networking-calico-%{version}.tar.gz
-Source45:	calico-dhcp-agent.service
-BuildArch:	noarch
+Source45:       calico-dhcp-agent.service
+BuildArch:      noarch
 Group:          Applications/Engineering
 Requires:       python-pbr
 
@@ -78,7 +78,7 @@ fi
 %package -n calico-dhcp-agent
 Group:          Applications/Engineering
 Summary:        Project Calico networking for OpenStack/Neutron
-Requires:       calico-common, networking-calico
+Requires:       calico-common, networking-calico, openstack-neutron-common
 
 %description -n calico-dhcp-agent
 This package provides the Calico DHCP agent.
@@ -92,6 +92,9 @@ This package provides the Calico DHCP agent.
 %if 0%{?el7}
 if [ $1 -eq 1 ] ; then
     # Initial installation
+    # FIXME - dhcp agent should log to /var/log/neutron
+    /bin/mkdir -p /var/log/calico
+    /usr/bin/chown neutron /var/log/calico
     /usr/bin/systemctl daemon-reload
     /usr/bin/systemctl enable calico-dhcp-agent
     /usr/bin/systemctl start calico-dhcp-agent
@@ -111,6 +114,7 @@ fi
 if [ $1 -ge 1 ] ; then
     # Package upgrade, not uninstall
 %if 0%{?el7}
+    /usr/bin/systemctl daemon-reload
     /usr/bin/systemctl condrestart calico-dhcp-agent >/dev/null 2>&1 || :
 %endif
 fi


### PR DESCRIPTION
By default the calico dhcp agent want's to run as root. A lot of trouble is awoided if the agent runs as the neutron user, like the neutron dhcp agent. These changes accomplishes that by changing the user in the systemd unit file and ensures that the logging directory is present with correct permissions.

This creates a dependency to openstack-neutron-common, since that package creates the neutron user and installs the necessary rootwrap scripts.