### PR TITLE
Add python3 support to debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: networking-calico
 Section: net
 Priority: optional
 Maintainer: Neil Jerram <neil@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), dh-systemd, python-all (>= 2.6), python-setuptools, python-pbr
+Build-Depends: debhelper (>= 8.0.0), dh-systemd, python-all (>= 2.6), python3-all (>= 3.5), python-setuptools, python3-setuptools, python-pbr, python3-pbr
 XS-Python-Version: >= 2.6
 Standards-Version: 3.9.4
 
@@ -11,7 +11,7 @@ Architecture: all
 Depends:
  bird,
  calico-felix (>= 1.4),
- networking-calico (= ${binary:Version}),
+ python3-networking-calico (= ${binary:Version}),
  neutron-dhcp-agent,
  iptables-persistent,
  ${misc:Depends},
@@ -30,7 +30,7 @@ Description: Project Calico networking for OpenStack/Neutron.
 Package: calico-dhcp-agent
 Architecture: all
 Depends:
- networking-calico (= ${binary:Version}),
+ python3-networking-calico (= ${binary:Version}),
  ${misc:Depends},
  ${python:Depends}
 Description: Project Calico networking for OpenStack/Neutron.
@@ -46,7 +46,7 @@ Description: Project Calico networking for OpenStack/Neutron.
 Package: calico-control
 Architecture: all
 Depends:
- networking-calico (= ${binary:Version}),
+ python3-networking-calico (= ${binary:Version}),
  ${misc:Depends},
  ${python:Depends}
 Description: Project Calico networking for OpenStack/Neutron.
@@ -59,7 +59,7 @@ Description: Project Calico networking for OpenStack/Neutron.
  .
  This package provides the pieces needed on a controller node.
 
-Package: networking-calico
+Package: python-networking-calico
 Architecture: all
 Depends:
  ${misc:Depends},
@@ -67,6 +67,27 @@ Depends:
  python-babel,
  python-eventlet,
  python-six
+Conflicts: networking-calico
+Replaces: networking-calico
+Description: Project Calico networking for OpenStack/Neutron.
+ Project Calico is an open source solution for virtual networking in
+ cloud data centers. It uses IP routing to provide connectivity
+ between the workloads in a data center that provide or use IP-based
+ services - whether VMs, containers or bare metal appliances; and
+ iptables, to impose any desired fine-grained security policy between
+ those workloads.
+ .
+ This package installs the networking-calico Calico/Neutron
+ integration code.
+
+Package: python3-networking-calico
+Architecture: all
+Depends:
+ ${misc:Depends},
+ python3-pbr,
+ python3-babel,
+ python3-eventlet,
+ python3-six
 Description: Project Calico networking for OpenStack/Neutron.
  Project Calico is an open source solution for virtual networking in
  cloud data centers. It uses IP routing to provide connectivity

--- a/debian/rules
+++ b/debian/rules
@@ -6,4 +6,4 @@
 export PBR_VERSION=
 
 %:
-	dh $@  --with python2,systemd
+	dh $@  --with python2,python3,systemd --buildsystem=pybuild


### PR DESCRIPTION
Split networking-calico package into python-networking-calico and python3-networking-calico varients
python-networking-calico conflicts and replaces networking-calico
Change packages to depend on python3-networking-calico