### PR TITLE
calico-dhcp-agent dhcp.py

### DIFF
--- a/networking_calico/agent/linux/dhcp.py
+++ b/networking_calico/agent/linux/dhcp.py
@@ -142,8 +142,8 @@ class DnsmasqRouted(dhcp.Dnsmasq):
             cmd.append('--server=%s' % server)
 
         try:
-            if self.dns_domain:
-                cmd.append('--domain=%s' % self.dns_domain)
+            if self.conf.dns_domain:
+                cmd.append('--domain=%s' % self.conf.dns_domain)
         except AttributeError:
             pass
 


### PR DESCRIPTION
provide fixed version of calico-dhcp-agent dhcp.py which is
confirmed to work against neutron 13.0.2 and 13.0.4.

neutron 13.0.4 introduced a change to the parent class dhcp.Dnsmasq
which is inherited by DnsmasqRouted in calico-dhcp-agent. This
change removed the member variable self.dns_domain which is used by
calico-dhcp-agent to correctly set the --domain dnsmasq parameter to
the value set in /etc/neutron/neutron.conf

this file has been updated to use self.conf.dns_domain which is
available in both 13.0.2 and 13.0.4